### PR TITLE
Fixed bugs in input validations

### DIFF
--- a/Src/InventoryManagement.Api/Features/Batches/CreateNewBatch/ItemOrderValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Batches/CreateNewBatch/ItemOrderValidator.cs
@@ -25,6 +25,8 @@ public class ItemOrderValidator : AbstractValidator<ItemOrder>
 
         RuleFor(x => x.BatchSize)
             .GreaterThanOrEqualTo(1)
-            .WithMessage(@"Item count must be greater than 0");
+            .WithMessage(@"Item count must be greater than 0")
+            .LessThan(int.MaxValue)
+            .WithMessage(@"Item count is too high.");
     }
 }

--- a/Src/InventoryManagement.Api/Features/Batches/DeleteBatchLine/DeleteBatchLineCommandValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Batches/DeleteBatchLine/DeleteBatchLineCommandValidator.cs
@@ -10,5 +10,8 @@ public class DeleteBatchLineCommandValidator : AbstractValidator<DeleteBatchLine
     {
         RuleFor(x => new BatchNumber(x.BatchNumber))
             .SetValidator(BatchNumberValidator.Instance);
+
+        RuleFor(x => new InventoryItemNumber(x.ItemNumber))
+            .SetValidator(InventoryItemNumberValidator.Instance);
     }
 }

--- a/Src/InventoryManagement.Api/Features/Shared/Validators/EmailValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Shared/Validators/EmailValidator.cs
@@ -24,7 +24,7 @@ public class EmailValidator : AbstractValidator<Email>
             .WithMessage(InvalidEmailMessage)
             .MaximumLength(256)
             .WithMessage(InvalidEmailMessage)
-            .Matches(@"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+            .Matches(@"^(?!.*\.\.)[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
             .WithMessage(InvalidEmailMessage);
     }
 }


### PR DESCRIPTION
Fixed following bugs in input validation.
- Quantity did not have a upper limit in `ItemOrder` validator.
- Item number validation rules were missing from the `DeleteBatchLineCommandValidator`
- `EmailValidator` allowed emails with two consecutive dots to be considered as a valid email.