### PR TITLE
Made the shared validator types internal to avoid them from being automatically registered in the DI container.

### DIFF
--- a/Src/InventoryManagement.Api/Features/Shared/Validators/BatchNumberValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Shared/Validators/BatchNumberValidator.cs
@@ -2,7 +2,7 @@
 
 namespace InventoryManagement.Api.Features.Shared.Validators;
 
-public class BatchNumberValidator : AbstractValidator<BatchNumber>
+internal class BatchNumberValidator : AbstractValidator<BatchNumber>
 {
     private static BatchNumberValidator? _instance;
 

--- a/Src/InventoryManagement.Api/Features/Shared/Validators/EmailValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Shared/Validators/EmailValidator.cs
@@ -2,7 +2,7 @@
 
 namespace InventoryManagement.Api.Features.Shared.Validators;
 
-public class EmailValidator : AbstractValidator<Email>
+internal class EmailValidator : AbstractValidator<Email>
 {
     private const string InvalidEmailMessage = @"Provided email is not valid.";
 

--- a/Src/InventoryManagement.Api/Features/Shared/Validators/ItemNumberValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Shared/Validators/ItemNumberValidator.cs
@@ -2,7 +2,7 @@
 
 namespace InventoryManagement.Api.Features.Shared.Validators;
 
-public class InventoryItemNumberValidator : AbstractValidator<InventoryItemNumber>
+internal class InventoryItemNumberValidator : AbstractValidator<InventoryItemNumber>
 {
     private static InventoryItemNumberValidator? _instance;
 

--- a/Src/InventoryManagement.Api/Features/Shared/Validators/PasswordValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Shared/Validators/PasswordValidator.cs
@@ -2,7 +2,7 @@
 
 namespace InventoryManagement.Api.Features.Shared.Validators;
 
-public class PasswordValidator : AbstractValidator<Password>
+internal class PasswordValidator : AbstractValidator<Password>
 {
     private static PasswordValidator? _instance;
 

--- a/Src/InventoryManagement.Api/Features/Shared/Validators/RoleNameValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Shared/Validators/RoleNameValidator.cs
@@ -2,7 +2,7 @@
 
 namespace InventoryManagement.Api.Features.Shared.Validators;
 
-public class RoleNameValidator : AbstractValidator<RoleName>
+internal class RoleNameValidator : AbstractValidator<RoleName>
 {
     private static RoleNameValidator? _instance;
 

--- a/Src/InventoryManagement.Api/Features/Shared/Validators/UserIdValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Shared/Validators/UserIdValidator.cs
@@ -2,7 +2,7 @@
 
 namespace InventoryManagement.Api.Features.Shared.Validators;
 
-public class UserIdValidator : AbstractValidator<UserId>
+internal class UserIdValidator : AbstractValidator<UserId>
 {
     private static UserIdValidator? _instance;
 


### PR DESCRIPTION
Made the shared validator types internal to avoid them from being automatically registered in the DI container.