### PR TITLE
Fixed validation bugs in Inventory Items feature

### DIFF
--- a/Src/InventoryManagement.Api/Features/Batches/ListBatchesByBatchNumber/BatchNumberFilterValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Batches/ListBatchesByBatchNumber/BatchNumberFilterValidator.cs
@@ -10,7 +10,7 @@ public class BatchNumberFilterValidator : AbstractValidator<BatchNumberFilter>
     {
         RuleFor(x => new InventoryItemNumber(x.InventoryItemId!))
             .SetValidator(InventoryItemNumberValidator.Instance)
-            .When(x => !string.IsNullOrWhiteSpace(x.InventoryItemId));
+            .When(x => x.InventoryItemId != null);
 
         RuleFor(x => x.IgnoreInactive)
             .NotNull()

--- a/Src/InventoryManagement.Api/Features/Batches/ListBatchesByBatchNumber/BatchNumberFilterValidator.cs
+++ b/Src/InventoryManagement.Api/Features/Batches/ListBatchesByBatchNumber/BatchNumberFilterValidator.cs
@@ -24,8 +24,8 @@ public class BatchNumberFilterValidator : AbstractValidator<BatchNumberFilter>
 
         RuleFor(q => q.ResultsPerPage)
             .NotNull()
-            .GreaterThan(0)
+            .GreaterThanOrEqualTo(10)
             .LessThanOrEqualTo(100)
-            .WithMessage(@"Results per page must be greater than 1 and not greater than 100");
+            .WithMessage(@"Results per page must not be less than 10 and must not be greater than 100");
     }
 }

--- a/Src/InventoryManagement.Api/Features/InventoryItems/CreateItem/NewItemInformationValidator.cs
+++ b/Src/InventoryManagement.Api/Features/InventoryItems/CreateItem/NewItemInformationValidator.cs
@@ -24,7 +24,7 @@ public class NewItemInformationValidator : AbstractValidator<NewItemInformation>
             .WithMessage("Measurement unit cannot be empty");
 
         RuleFor(info => info.MeasurementUnit)
-            .Length(1, 10)
+            .Length(1, 15)
             .WithMessage(@"Measurement unit must be between 1 and 10 characters");
     }
 }

--- a/Src/InventoryManagement.Api/Features/InventoryItems/CreateItem/NewItemInformationValidator.cs
+++ b/Src/InventoryManagement.Api/Features/InventoryItems/CreateItem/NewItemInformationValidator.cs
@@ -24,7 +24,7 @@ public class NewItemInformationValidator : AbstractValidator<NewItemInformation>
             .WithMessage("Measurement unit cannot be empty");
 
         RuleFor(info => info.MeasurementUnit)
-            .Length(1, 15)
-            .WithMessage(@"Measurement unit must be between 1 and 10 characters");
+            .Matches(@"^[a-zA-Z]{1,15}$")
+            .WithMessage(@"Measurement unit must be between 1 and 15 characters and must contain only uppercase and lowercase characters.");
     }
 }

--- a/Src/InventoryManagement.Api/Features/InventoryItems/ListItems/ListItemQueryValidator.cs
+++ b/Src/InventoryManagement.Api/Features/InventoryItems/ListItems/ListItemQueryValidator.cs
@@ -9,7 +9,7 @@ public class ListItemQueryValidator : AbstractValidator<ListItemsQuery>
         RuleFor(query => query.ItemNamePartToSearch)
             .MaximumLength(50)
             .WithMessage("Maximum length of a item name is 50 characters.")
-            .When(query => query.ItemNamePartToSearch != string.Empty && string.IsNullOrWhiteSpace(query.ItemNamePartToSearch));
+            .When(query => query.ItemNamePartToSearch != string.Empty && !string.IsNullOrWhiteSpace(query.ItemNamePartToSearch));
 
         RuleFor(query => query.PageNumber)
             .GreaterThanOrEqualTo(1)

--- a/Tests/InventoryManagement.UnitTests/ValidatorUnitTests/ValidatorTestCaseSources.cs
+++ b/Tests/InventoryManagement.UnitTests/ValidatorUnitTests/ValidatorTestCaseSources.cs
@@ -229,7 +229,7 @@ internal class ValidatorTestCaseSources
 
     public static IEnumerable<string?> InvalidMeasurementUnitSource()
     {
-        yield return "hgfhsfjsAnvybda";
+        yield return "hgfhsfjsAnvybdak";
         yield return "ADE1";
         yield return "517";
         yield return "";


### PR DESCRIPTION
Fixed validation bugs in Inventory Items feature
- Increased the lower limit of `record per page` value of the `BatchNumberFilter`.
- Fixed a bug in `BatchNumberFilterValidator` which caused empty and whitespace strings to be validated as valid ones.
- Introduced regex for matching measurement unit in validator.
- Increased the maximum length of measurement unit to 15 characters.
- Fixed a bug in `ListItemQueryValidator` which caused any string to be validated as a valid item name part.